### PR TITLE
ADD Support for extra v4l2loopback devices

### DIFF
--- a/gopro
+++ b/gopro
@@ -5,6 +5,9 @@
 #Author       	:Joshua Schmid
 #Email         	:jxs@posteo.de
 ###################################################################
+# Update
+# 2021-12-28 ADD Support for extra v4l2loopback devices. Due to OBS webcam Johan Hörting
+###################################################################
 
 VERSION=0.0.3
 
@@ -33,6 +36,7 @@ globals() {
     # TODO: rename AUTO -> NONINTERACTIVE
     GOPRO_NON_INTERACTIVE=${GOPRO_NON_INTERACTIVE:-0}
     GOPRO_AUTOSTART=${GOPRO_AUTOSTART:-0}
+    GOPRO_V4l2_DEVICES=${GOPRO_V4l2_DEVICES}
     GOPRO_PREVIEW=${GOPRO_PREVIEW:-0}
     GOPRO_RESOLUTION=${GOPRO_RESOLUTION:-1080}
     GOPRO_FOV_ID=${GOPRO_FOV_ID:-4}
@@ -46,6 +50,7 @@ globals() {
 DEPS=( "ffmpeg" "curl" )
 module="v4l2loopback"
 module_cmd="modprobe v4l2loopback exclusive_caps=1 card_label='GoPro' video_nr=42"
+module_v4l2_devices_cmd="modprobe v4l2loopback devices=%s exclusive_caps=1 card_label='GoPro' video_nr=42"
 module_cmd_unload="modprobe -rf v4l2loopback"
 
 START_PATH="/gp/gpWebcam/START?res="
@@ -64,6 +69,9 @@ function run_args {
     >&2 echo " * Preview:          $GOPRO_PREVIEW"
     >&2 echo " * Resolution:       ${GOPRO_RESOLUTION}p"
     >&2 echo " * FOV:              $GOPRO_FOV"
+    if [[ $GOPRO_V4l2_DEVICES ]]; then
+    >&2 echo " * V4l2 Devices:     $GOPRO_V4l2_DEVICES"
+    fi 
     if [[ $GOPRO_DEVICE ]]; then
     >&2 echo " * Device:           $GOPRO_DEVICE"
     fi 
@@ -140,11 +148,13 @@ Options:
   
   -a,  --auto-start        automatically start ffmpeg to serve the GoPro as a video device to your operating system.
                            If this flag is omitted, print the corresponding command to run it yourself. 
-
+  
+  -x,  --v4l2-devices	   Number of v4l2loopback devices. Default 1.  
+  
   -v,  --preview           Just launch a preview in VLC. This will not expose the device to the OS.
 
   -u,  --user              VLC can't be started as root, please provide a username you want to run it with. (Typically your 'default/home' user)
-
+ 
   -V,  --verbose           echo every command that gets executed
 
   -h,  --help              display this help
@@ -196,6 +206,9 @@ function parse_args {
         ;;
       -a|--auto-start)
         GOPRO_AUTOSTART=1
+        ;;
+      -x|--v4l2-devices)
+        GOPRO_V4l2_DEVICES=$2
         ;;
       -v|--preview)
         DEPS+=('vlc')
@@ -322,7 +335,8 @@ function find_gopro_ip {
     mangled_ip=$(echo ${GOPRO_IP} | awk -F"." '{print $1"."$2"."$3".51"}')
     green "Now using this GOPRO_IP internally: ${mangled_ip}"
 
-    GOPRO_INTERFACE_IP=$mangled_ip
+    
+    GOPRO_INTERFACE_IP=$mangled_ip    
 }
 
 function start_gopro_webcam_mode {
@@ -411,6 +425,11 @@ main() {
         # If module is loaded already, unload it, to maintain idempotency.
         test_module_loaded
 
+    	if [[ ${GOPRO_V4l2_DEVICES} ]]; then
+           module_cmd="${module_cmd} devices=${GOPRO_V4l2_DEVICES}"
+           green "Load cmd: ${module_cmd}."
+    	fi
+    	
         # modprobe the needed kernel module
         test_module_probe
 


### PR DESCRIPTION
I had problems getting the virtual camera started in the OBS studio. Added extra argument for number of v4l2loopback devices.
sudo gopro webcam -x 2 -a